### PR TITLE
Add {% seo %} liquid tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    {% seo %}
     <title>{{ page.title }}</title>
     
     <link rel="stylesheet" type="text/css" href="/css/main.css">


### PR DESCRIPTION
According to jekyll.tips/jekyll-casts/seo-in-jekyll/ SEO can be added by adding {% seo %} liquid tag to <home>. Implementing this will allow to improve SEO on site.